### PR TITLE
Move hardcoded addresses to addresses.ts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { MULTICALL3_ADDRESS } from './constants/addresses'
 
 const projectId = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID
 
-const holeskyChain = defineChain({
+export const defaultChain = defineChain({
   id: DEFAULT_CHAIN_ID,
   network: 'holesky',
   name: 'Holesky',
@@ -44,7 +44,7 @@ const holeskyChain = defineChain({
   testnet: true,
 })
 
-const chains = [holeskyChain]
+const chains = [defaultChain]
 const wagmiConfig = defaultWagmiConfig({ chains, projectId, metadata: { name: 'Algebra Integral', description: 'DEX Engine', url: 'https://integral.algebra.finance', icons: [''] } })
 
 createWeb3Modal({ 
@@ -54,7 +54,7 @@ createWeb3Modal({
   chainImages: {
     [DEFAULT_CHAIN_ID]: ETHLogo
   },
-  defaultChain: holeskyChain,
+  defaultChain: defaultChain,
   themeVariables: {
     '--w3m-accent': '#2797ff'
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,13 @@ import Layout from "@/components/common/Layout"
 import { defineChain } from "viem"
 
 import ETHLogo from '@/assets/tokens/ether.svg'
+import { DEFAULT_CHAIN_ID } from './constants/default-chain-id'
+import { MULTICALL3_ADDRESS } from './constants/addresses'
 
 const projectId = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID
 
 const holeskyChain = defineChain({
-  id: 17000,
+  id: DEFAULT_CHAIN_ID,
   network: 'holesky',
   name: 'Holesky',
   nativeCurrency: { name: 'Holesky Ether', symbol: 'ETH', decimals: 18 },
@@ -35,7 +37,7 @@ const holeskyChain = defineChain({
   },
   contracts: {
     multicall3: {
-      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      address: MULTICALL3_ADDRESS,
       blockCreated: 77,
     },
   },
@@ -50,7 +52,7 @@ createWeb3Modal({
   projectId, 
   chains, 
   chainImages: {
-    17000: ETHLogo
+    [DEFAULT_CHAIN_ID]: ETHLogo
   },
   defaultChain: holeskyChain,
   themeVariables: {

--- a/src/components/common/CurrencyLogo/index.tsx
+++ b/src/components/common/CurrencyLogo/index.tsx
@@ -7,6 +7,7 @@ import WBTCLogo from '@/assets/tokens/wbtc.svg'
 import EtherLogo from '@/assets/tokens/ether.svg'
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
+import { USDC_ADDRESS, USDT_ADDRESS, WBTC_ADDRESS, WNATIVE_ADDRESS } from "@/constants/addresses";
 
 interface CurrencyLogoProps {
     currency: Currency | undefined | null;
@@ -16,22 +17,22 @@ interface CurrencyLogoProps {
 }
 
 export const specialTokens: { [key: Address]: { symbol: string; logo: string } } = {
-    ['0x94373a4919b3240d86ea41593d5eba789fef3848']: {
+    [WNATIVE_ADDRESS]: {
         symbol: 'ETH',
         logo: EtherLogo
     },
-    ['0x7d98346b3b000c55904918e3d9e2fc3f94683b01']: {
+    [USDT_ADDRESS]: {
         symbol: 'USDT',
         logo: USDTLogo
     },
-    ['0x9dad8a1f64692adeb74aca26129e0f16897ff4bb']: {
-        symbol: 'WBTC',
-        logo: WBTCLogo
-    },
-    ['0x6581e59a1c8da66ed0d313a0d4029dce2f746cc5']: {
+    [USDC_ADDRESS]: {
         symbol: 'USDC',
         logo: USDCLogo
-    }
+    },
+    [WBTC_ADDRESS]: {
+      symbol: 'WBTC',
+      logo: WBTCLogo
+  },
 }
 
 

--- a/src/components/common/TransactionCard/index.tsx
+++ b/src/components/common/TransactionCard/index.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 import { Transaction, TransactionType } from "@/state/pendingTransactionsStore";
 import Loader from "../Loader";
 import { FarmingPositionImg } from "@/components/farming/FarmingPositionImg";
+import { defaultChain } from "@/App";
 
 export const TransactionCard = ({ hash, transaction }: { hash: Address, transaction: Transaction }) => {
     const currencyA = useCurrency(transaction.data.tokenA, true);
@@ -16,7 +17,7 @@ export const TransactionCard = ({ hash, transaction }: { hash: Address, transact
     const txType = transaction.data.type;
 
     return <Link
-            to={`https://holesky.etherscan.io/tx/${hash}`}
+            to={`${defaultChain.blockExplorers.default.url}/tx/${hash}`}
             target={'_blank'}
             >
                 <li className="flex group h-16 justify-between items-center gap-4 w-full bg-card-dark rounded-3xl p-4 border border-border/60 hover:border-border hover:bg-card-dark/60 transition-all duration-200" key={hash}>

--- a/src/constants/addresses.ts
+++ b/src/constants/addresses.ts
@@ -26,3 +26,18 @@ export const ALGEBRA_ETERNAL_FARMING: Address =
 
 export const FARMING_CENTER: Address =
     '0x37A4950b4ea0C46596404895c5027B088B0e70e7';
+
+export const WNATIVE_ADDRESS: Address =
+    '0x94373a4919b3240d86ea41593d5eba789fef3848';
+
+export const USDT_ADDRESS: Address =
+    '0x7d98346b3b000c55904918e3d9e2fc3f94683b01';
+
+export const USDC_ADDRESS: Address =
+    '0x6581e59a1c8da66ed0d313a0d4029dce2f746cc5';
+
+export const WBTC_ADDRESS: Address =
+    '0x9dad8a1f64692adeb74aca26129e0f16897ff4bb';
+
+export const MULTICALL3_ADDRESS: Address =
+    '0xca11bde05977b3631167028862be2a173976ca11';

--- a/src/constants/routing.ts
+++ b/src/constants/routing.ts
@@ -1,12 +1,16 @@
-import { WNATIVE, Token, ChainId } from "@cryptoalgebra/integral-sdk"
 import { STABLECOINS } from "./tokens"
+import { Token } from "@cryptoalgebra/integral-sdk"
+import { WNATIVE_ADDRESS } from "./addresses"
+import { DEFAULT_CHAIN_ID } from "./default-chain-id"
 
 type ChainTokenList = {
     readonly [chainId: number]: Token[]
 }
 
+export const WNATIVE_TOKEN = new Token(DEFAULT_CHAIN_ID, WNATIVE_ADDRESS, 18, 'WETH', 'Wrapped Ether')
+
 export const WNATIVE_EXTENDED: { [chainId: number]: Token } = {
-    ...WNATIVE
+    [DEFAULT_CHAIN_ID]: WNATIVE_TOKEN
 }
 
 const WNATIVE_ONLY: ChainTokenList = Object.fromEntries(
@@ -15,5 +19,5 @@ const WNATIVE_ONLY: ChainTokenList = Object.fromEntries(
 
 export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
     ...WNATIVE_ONLY,
-    [ChainId.Holesky]: [...WNATIVE_ONLY[ChainId.Holesky], STABLECOINS.USDT]
+    [DEFAULT_CHAIN_ID]: [...WNATIVE_ONLY[DEFAULT_CHAIN_ID], STABLECOINS.USDT]
 }

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -1,6 +1,7 @@
 import { Token } from "@cryptoalgebra/integral-sdk";
 import { DEFAULT_CHAIN_ID } from "./default-chain-id";
+import { USDT_ADDRESS } from "./addresses";
 
 export const STABLECOINS = {
-    USDT: new Token(DEFAULT_CHAIN_ID, '0x7d98346b3b000c55904918e3d9e2fc3f94683b01', 6, 'USDT', 'USDT')
+    USDT: new Token(DEFAULT_CHAIN_ID, USDT_ADDRESS, 6, 'USDT', 'USDT')
 }

--- a/src/hooks/common/useCurrency.ts
+++ b/src/hooks/common/useCurrency.ts
@@ -2,18 +2,18 @@ import { Address } from 'wagmi';
 import {
     Currency,
     ExtendedNative,
-    WNATIVE
 } from '@cryptoalgebra/integral-sdk';
 import { ADDRESS_ZERO } from "@cryptoalgebra/integral-sdk";
 import { DEFAULT_CHAIN_ID, DEFAULT_NATIVE_NAME, DEFAULT_NATIVE_SYMBOL } from "@/constants/default-chain-id";
 import { useAlgebraToken } from "./useAlgebraToken";
+import { WNATIVE_ADDRESS } from '@/constants/addresses';
 
 export function useCurrency(
     address: Address | undefined,
     withNative?: boolean
 ): Currency | ExtendedNative | undefined {
 
-    const isWNative = address?.toLowerCase() === WNATIVE[DEFAULT_CHAIN_ID].address.toLowerCase()
+    const isWNative = address?.toLowerCase() === WNATIVE_ADDRESS.toLowerCase()
 
     const isNative = address === ADDRESS_ZERO;
 

--- a/src/hooks/common/useTransactionAwait.tsx
+++ b/src/hooks/common/useTransactionAwait.tsx
@@ -1,3 +1,4 @@
+import { defaultChain } from '@/App';
 import { ToastAction } from '@/components/ui/toast';
 import { useToast } from '@/components/ui/use-toast';
 import { TransactionInfo, usePendingTransactionsStore } from '@/state/pendingTransactionsStore';
@@ -10,7 +11,7 @@ export const ViewTxOnExplorer = ({ hash }: { hash: Address | undefined }) =>
     hash ? (
         <ToastAction altText="View on explorer" asChild>
             <Link
-                to={`https://holesky.etherscan.io/tx/${hash}`}
+                to={`${defaultChain.blockExplorers.default.url}/tx/${hash}`}
                 target={'_blank'}
                 className="border-none gap-2 hover:bg-transparent hover:text-blue-400"
             >

--- a/src/hooks/swap/useWrapCallback.ts
+++ b/src/hooks/swap/useWrapCallback.ts
@@ -1,11 +1,12 @@
 import { WNATIVE_EXTENDED } from "@/constants/routing";
 import { usePrepareWrappedNativeDeposit, usePrepareWrappedNativeWithdraw } from "@/generated";
-import { Currency, WNATIVE, tryParseAmount } from "@cryptoalgebra/integral-sdk";
+import { Currency, tryParseAmount } from "@cryptoalgebra/integral-sdk";
 import { useMemo } from "react";
 import { Address, useAccount, useBalance, useChainId, useContractWrite } from "wagmi";
 import { useTransactionAwait } from "../common/useTransactionAwait";
 import { DEFAULT_NATIVE_SYMBOL } from "@/constants/default-chain-id";
 import { TransactionType } from "@/state/pendingTransactionsStore";
+import { WNATIVE_ADDRESS } from "@/constants/addresses";
 
 export const WrapType = {
     NOT_APPLICABLE: 'NOT_APPLICABLE',
@@ -27,7 +28,7 @@ export default function useWrapCallback(
     const inputAmount = useMemo(() => tryParseAmount(typedValue, inputCurrency), [inputCurrency, typedValue])
 
     const { config: wrapConfig } = usePrepareWrappedNativeDeposit({
-        address: WNATIVE[chainId].address as Address,
+        address: WNATIVE_ADDRESS as Address,
         value: inputAmount ? BigInt(inputAmount.quotient.toString()) : undefined
     })
 
@@ -37,13 +38,13 @@ export default function useWrapCallback(
         wrapData?.hash,
         { 
             title: `Wrap ${inputAmount?.toSignificant(3)} ${DEFAULT_NATIVE_SYMBOL}`,
-            tokenA: WNATIVE[chainId].address as Address,
+            tokenA: WNATIVE_ADDRESS as Address,
             type: TransactionType.SWAP
         }
     )
 
     const { config: unwrapConfig } = usePrepareWrappedNativeWithdraw({
-        address: WNATIVE[chainId].address as Address,
+        address: WNATIVE_ADDRESS as Address,
         args: inputAmount ? [BigInt(inputAmount.quotient.toString())] : undefined
     })
 
@@ -53,7 +54,7 @@ export default function useWrapCallback(
         unwrapData?.hash,
         { 
             title: `Unwrap ${inputAmount?.toSignificant(3)} W${DEFAULT_NATIVE_SYMBOL}`,
-            tokenA: WNATIVE[chainId].address as Address,
+            tokenA: WNATIVE_ADDRESS as Address,
             type: TransactionType.SWAP,
         }
     )   


### PR DESCRIPTION
This PR moves all addresses scattered in various file to a single file (single point of "truth"): addresses.ts

Also the blockchain explorer address was hardcoded and now taken from App.tsx `defaultChain`.
This allows to make a new branch based on master and easily update addresses in just these 2 files:
- addresses.ts
- App.tsx & default-chain-id.ts (blockchain info)
- .env (subgraph urls)

There are still some hardcoded addresses in SwapChart/index.ts that should be removed, but this could be done in a separate commit/PR.